### PR TITLE
use the npm version of realm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dhtmlx-gantt": "^4.1.0",
     "express": "^4.15.2",
     "octokat": "^0.6.4",
-    "realm": "file:realm-professional.tgz"
+    "realm": "^1.2.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Thanks for mentioning [octokat](https://github.com/philschatz/octokat.js) in your [post](https://realm.io/news/gantt-chart-from-github-issues-caching-architecture-using-realm/)!

I was unable to run `./setup.sh` but changing the version of realm to use the one on npm fixed the problem.

Also, I had not heard of [dhtmlxGantt](https://dhtmlx.com/docs/products/dhtmlxGantt/) when adding Gantt charts to [gh-board](https://github.com/philschatz/gh-board) but I like the Issue template approach (instead of my hacky milestone one).